### PR TITLE
✨ ngx-cookieを依存ライブラリに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "angulartics2": "^1.6.4",
     "core-js": "^2.4.1",
     "intl": "^1.2.5",
+    "ngx-cookie": "^1.0.0",
     "rxjs": "^5.1.0",
     "zone.js": "^0.8.4"
   },

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -7,12 +7,14 @@ import { HttpModule } from '@angular/http';
 import { FormsModule } from '@angular/forms';
 import { HeaderComponent } from './header/header.component';
 import { HeaderService } from './header/header.service';
+import { CookieModule } from 'ngx-cookie';
 
 @NgModule({
   imports: [
     CommonModule,
     HttpModule,
     FormsModule,
+    CookieModule.forChild()
   ],
   exports: [HeaderComponent],
   declarations: [HeaderComponent],


### PR DESCRIPTION
CookieをAngularJSっぽく扱えるngx-cookieを追加しています。
CoreModuleにもインポートしています。