### PR TITLE
AuthGuardServiceを作成

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { AboutPerfumeHubComponent } from './about-perfume-hub/about-perfume-hub.component';
 import { AdminComponent } from './admin/admin.component';
+import { AuthGuardService } from './core/auth-guard.service';
 
 const routes: Routes = [
   {
@@ -28,7 +29,8 @@ const routes: Routes = [
   },
   {
     path: 'notification',
-    loadChildren: './notification/notification.module#NotificationModule'
+    loadChildren: './notification/notification.module#NotificationModule',
+    canLoad: [AuthGuardService]
   },
   {
     path: '**',
@@ -38,6 +40,7 @@ const routes: Routes = [
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
+  providers: [AuthGuardService]
 })
 export class AppRoutingModule { }

--- a/src/app/core/auth-guard.service.spec.ts
+++ b/src/app/core/auth-guard.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { AuthGuardService } from './auth-guard.service';
+
+describe('AuthGuardService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AuthGuardService]
+    });
+  });
+
+  it('should be created', inject([AuthGuardService], (service: AuthGuardService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/core/auth-guard.service.ts
+++ b/src/app/core/auth-guard.service.ts
@@ -9,7 +9,7 @@ export class AuthGuardService {
   constructor(private userService: UserService,
               private router: Router) { }
 
-  canLoad(route: Route): boolean|Observable<boolean>{
+  canLoad(route: Route): boolean|Observable<boolean> {
     return this.userService.getUser()
       .map(data => {
         if (data) {

--- a/src/app/core/auth-guard.service.ts
+++ b/src/app/core/auth-guard.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Route, Router, RouterStateSnapshot } from '@angular/router';
+import { UserService } from './user.service';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class AuthGuardService {
+
+  constructor(private userService: UserService,
+              private router: Router) { }
+
+  canLoad(route: Route): boolean|Observable<boolean>{
+    return this.userService.getUser()
+      .map(data => {
+        if (data) {
+          return true;
+        } else {
+          console.log('not authenticated');
+          // TODO ここでダイアログを出したい
+
+          // 一旦Scheduleに飛ばす
+          this.router.navigate(['/schedule']);
+          return false;
+        }
+      });
+  }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    return this.userService.getUser()
+      .map( data => {
+        if (data) {
+          return true;
+        } else {
+          // TODO ここでダイアログを出したい
+
+          // 一旦Scheduleに飛ばす
+          this.router.navigate(['/']);
+          return false;
+        }
+      });
+  }
+
+}


### PR DESCRIPTION
## 概要
LazyLoadingなModuleには`canLoad`を  
そうでないものは`canActivate`をRouteに入れることで  
認証していない場合のアクセスをブロックできるようになる  
まとめてAuthGuardServiceの中に入れました。  

主に必要になってくるのは管理者が使う画面なので  
ログインしているかどうかだけでは不十分だと思います。
追加でAdminGuard的なものを作らないといけないかもですが  
とりあえずGuardのお勉強も兼ねて普通のAuthGuardを作ってみた感じです。

## 参考
https://angular.io/docs/ts/latest/guide/router.html#!#can-activate-guard