### PR TITLE
🚑 iOS9以下の端末で正しく表示されていない不具合を修正

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -66,3 +66,7 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
  */
 import 'intl';  // Run `npm install --save intl`.
+/**
+ * Need to import at least one locale-data with intl.
+ */
+import 'intl/locale-data/jsonp/en';


### PR DESCRIPTION
intlのpolyfillのimportが不十分でした。  
最新のangular-cliでプロジェクトを作成して生成されたpolyfills.tsから必要なコードをコピーしました。