### PR TITLE
✨ ネイティブアプリと連携するためのサービスを追加

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,7 @@
 import { ApplicationRef, Component, OnInit } from '@angular/core';
 import { Angulartics2GoogleAnalytics } from 'angulartics2';
 import { HeaderService } from './core/header/header.service';
-
-
-declare global {
-  interface Window {
-    WebViewJavascriptBridge: any;
-    WVJBCallbacks: any;
-  }
-}
+import { NativeBridgeService } from './core/native-bridge.service';
 
 @Component({
   selector: 'ph-root',
@@ -19,35 +12,29 @@ export class AppComponent implements OnInit {
 
   constructor(private headerService: HeaderService,
               angulartics2GoogleAnalytics: Angulartics2GoogleAnalytics,
-              private appRef: ApplicationRef) {}
-
-  setupWebViewJavascriptBridge(callback) {
-    if (Window.prototype.WebViewJavascriptBridge) { return callback(Window.prototype.WebViewJavascriptBridge); }
-    if (Window.prototype.WVJBCallbacks) { return window.WVJBCallbacks.push(callback); }
-    window.WVJBCallbacks = [callback];
-    const WVJBIframe = document.createElement('iframe');
-    WVJBIframe.style.display = 'none';
-    WVJBIframe.src = 'https://__bridge_loaded__';
-    document.documentElement.appendChild(WVJBIframe);
-    setTimeout(function() { document.documentElement.removeChild(WVJBIframe); }, 0);
-  }
+              private appRef: ApplicationRef,
+              private nativeBridge: NativeBridgeService) {}
 
   ngOnInit() {
+    if (this.nativeBridge.isApp()) {
+      this.nativeBridge.registerHandler('setThemeColor', this.setThemeColor);
 
-    this.setupWebViewJavascriptBridge(bridge => {
+      // アプリ側にWebの準備ができたことを伝える
+      this.nativeBridge.callHandler('AppReady', {}, responseData => {});
+    }
+  }
 
-      // 色の変更を行う
-      bridge.registerHandler('setThemeColor', (data, responseCallback) => {
-        this.headerService.setColor(data);
-        // tickしてビューに反映させる
-        this.appRef.tick();
-        responseCallback(data);
-      });
-
-      // ネイティブにアプリの準備ができたことを伝える
-      bridge.callHandler('App Ready', {}, responseData => { });
-
-    });
+  /**
+   * テーマカラーの変更を行います
+   * @param data
+   * @param responseCallback
+   */
+  setThemeColor(data: string, responseCallback: (callbackData) => {}) {
+    this.headerService.setColor(data);
+    // tickしてAngularのCDを動かす
+    this.appRef.tick();
+    // エコーバック
+    responseCallback(data);
   }
 
 }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -12,6 +12,7 @@ import { AppMenuComponent } from './app-menu/app-menu.component';
 import { RouterModule } from '@angular/router';
 import { LoadingSpinnerComponent } from './loading-spinner/loading-spinner.component';
 import { LoadingSpinnerService } from './loading-spinner/loading-spinner.service';
+import { NativeBridgeService } from './native-bridge.service';
 
 @NgModule({
   imports: [
@@ -23,6 +24,6 @@ import { LoadingSpinnerService } from './loading-spinner/loading-spinner.service
   ],
   exports: [HeaderComponent, AppMenuComponent, LoadingSpinnerComponent],
   declarations: [HeaderComponent, AppMenuComponent, LoadingSpinnerComponent],
-  providers: [ApiBaseService, UserService, HeaderService, LoadingSpinnerService]
+  providers: [ApiBaseService, UserService, HeaderService, LoadingSpinnerService, NativeBridgeService]
 })
 export class CoreModule { }

--- a/src/app/core/native-bridge.service.spec.ts
+++ b/src/app/core/native-bridge.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { NativeBridgeService } from './native-bridge.service';
+
+describe('NativeBridgeService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NativeBridgeService]
+    });
+  });
+
+  it('should be created', inject([NativeBridgeService], (service: NativeBridgeService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/core/native-bridge.service.ts
+++ b/src/app/core/native-bridge.service.ts
@@ -1,0 +1,123 @@
+import { Injectable } from '@angular/core';
+
+declare global {
+  interface Window {
+    WebViewJavascriptBridge: any;
+    WVJBCallbacks: any;
+  }
+}
+
+@Injectable()
+export class NativeBridgeService {
+
+  private bridge: any = {};
+
+  private callQueue = [];
+  private handlerQueue = [];
+
+  constructor() {
+
+    // When using PC Chrome (For development) or
+    // using normal browsers (e.g. Safari) mock native bridge functions.
+    if (window.navigator.userAgent.indexOf('PerfumeHubDev') !== -1 || !this.isApp()) {
+      this.bridge.callHandler = (name, data, responseCallback) => {
+        console.log('Native call:' + name, data);
+      };
+      this.bridge.registerHandler = (name, callback) => {
+        console.log('Register handler: ' + name);
+      }; 
+      return;
+    }
+
+    this.setupWebViewJavascriptBridge(bridge => {
+      this.bridge = bridge;
+
+      // Tell native WebView that Angular is ready
+      bridge.callHandler('App Ready', {});
+
+      // When call or handle function has called during init,
+      // Flush them when bridge is ready.
+      if (this.handlerQueue.length > 0 || this.callQueue.length > 0) {
+        this.flush();
+      }
+    });
+  }
+
+  /**
+   * Check WebView that is in-app WebView or Safari/Chrome
+   * @returns {boolean}
+   */
+  isApp() {
+    return window.navigator.userAgent.indexOf('PerfumeHub') !== -1;
+  }
+
+  /**
+   * Call native WebView
+   * @param name
+   * @param data
+   * @param callback
+   * @usage
+   *   service.callHandler('ObjC Echo', {'key': 'value'}, function responseCallback(responseData) {
+   *     console.log('JS received response:', responseData);
+   *   });
+   */
+  callHandler(name: string, data: any, callback?) {
+    // When bridge is not ready, push into queue.
+    if (!(this.bridge || {}).callHandler) {
+      this.callQueue.push({name: name, data: data, callback: callback});
+      return;
+    }
+    this.bridge.callHandler(name, data, callback);
+  }
+
+  /**
+   * Register handler
+   * @param name
+   * @param callback
+   *
+   * @usage
+   *   service.registerHandler('JS Echo', function (data, responseCallback){
+   *     console.log('JS Echo called with:', data);
+   *     responseCallback(data);
+   *   });
+   */
+  registerHandler(name: string, callback) {
+    // When bridge is not ready, push into queue.
+    if (!(this.bridge || {}).registerHandler) {
+      this.handlerQueue.push({name: name, callback: callback});
+      return;
+    }
+    this.bridge.registerHandler(name, callback);
+  }
+
+  /**
+   * Flush queue
+   */
+  private flush() {
+    this.callQueue.forEach(call => {
+      this.callHandler(call.name, call.data, call.callback);
+    });
+    this.callQueue = [];
+    this.handlerQueue.forEach(handler => {
+      this.registerHandler(handler.name, handler.callback);
+    });
+    this.handlerQueue = [];
+  }
+
+  /**
+   * Set up native-web bridge
+   * from https://github.com/marcuswestin/WebViewJavascriptBridge
+   * @param callback
+   * @returns {any}
+   */
+  private setupWebViewJavascriptBridge(callback) {
+    if (Window.prototype.WebViewJavascriptBridge) { return callback(Window.prototype.WebViewJavascriptBridge); }
+    if (Window.prototype.WVJBCallbacks) { return window.WVJBCallbacks.push(callback); }
+    window.WVJBCallbacks = [callback];
+    const WVJBIframe = document.createElement('iframe');
+    WVJBIframe.style.display = 'none';
+    WVJBIframe.src = 'https://__bridge_loaded__';
+    document.documentElement.appendChild(WVJBIframe);
+    setTimeout(function() { document.documentElement.removeChild(WVJBIframe); }, 0);
+  }
+}


### PR DESCRIPTION
PerfumeHubのアプリ版と連携するためのサービスを作成しました。
Webアプリ起動時に`AppReady`をネイティブに向けて呼びます。
通常のブラウザからのアクセスや開発環境の場合にはコールをモックしたものが使用されます。
ネイティブを呼びたい場合には `isApp()` で判定してから使うようにしてください。