### PR TITLE
💚 node_modules内のlintを無効にした

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -39,7 +39,8 @@
   },
   "lint": [
     {
-      "project": "src/tsconfig.app.json"
+      "project": "src/tsconfig.app.json",
+      "exclude": "**/node_modules/**/*"
     },
     {
       "project": "src/tsconfig.spec.json"


### PR DESCRIPTION
yarnで追加したngx-ui-switchがlintでコケるため。